### PR TITLE
build(Makefile): fixing some commands and including 'make exec' command.

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -16,7 +16,7 @@ hard-install: ## Install hard client dependencies
 	@echo "Hard installing dependencies client"
 	rm -rf node_modules
 	rm -rf pnpm-lock.yaml
-	pnpm install
+	make install
 
 start-debug: ## Run client (by default in watch mode)
 	@echo "Starting client"
@@ -34,7 +34,7 @@ stop: ## Run client
 	@echo "Stoping client"
 	docker-compose stop client
 
-test: ## Run client tests
+test: ## Run client tests on client
 	@echo "Testing client with jest"
 	pnpm test
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -1,6 +1,16 @@
+CONTAINER_NAME = client-codenaute
+
+# If the first argument is "run"...
+ifeq (exec,$(firstword $(MAKECMDGOALS)))
+  # use the rest as arguments for "run"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+
 install: ## Install client dependencies
 	@echo "Installing dependencies server"
-	# TODO: Implement Install
+	pnpm install
 
 hard-install: ## Install hard client dependencies
 	@echo "Hard installing dependencies client"
@@ -15,6 +25,10 @@ start-debug: ## Run client (by default in watch mode)
 start-quiet: ## Start cliennt in mode quiet
 	@echo "Starting client in mode quiet"
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose up -d --build client
+
+.PHONY: exec
+exec : ## Running server container
+	@echo docker exec $(CONTAINER_NAME) $(RUN_ARGS)
 
 stop: ## Run client
 	@echo "Stoping client"
@@ -32,9 +46,5 @@ prettier-fix: ## Run prettier
 	@echo "Running prettier"
 	npx prettier --write .
 
-.PHONY: install
-.PHONY: hard-install
-.PHONY: start
-.PHONY: watch
-.PHONY: test
-.PHONY: pretier
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'

--- a/database/Makefile
+++ b/database/Makefile
@@ -8,7 +8,7 @@ start-debug: ## Starting database in debug mode
 
 stop: ## Stoping database
 	@echo "Stoping database"
-	docker-compose stop postgres adminer redis
+	docker-compose stop postgres adminer redis postgres-test
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,3 +1,13 @@
+CONTAINER_NAME = server-codenaute
+
+# If the first argument is "run"...
+ifeq (exec,$(firstword $(MAKECMDGOALS)))
+  # use the rest as arguments for "run"
+  RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(RUN_ARGS):;@:)
+endif
+
 install: ## Installing server dependencies
 	@echo "Installing server dependencies"
 	pnpm install
@@ -12,21 +22,25 @@ build: ## Compiling typescript
 	@echo "Building typescript on server"
 	pnpm build
 
-start-debug: ## Starting server in debug mode
+start-debug: ## Starting server container in debug mode
 	@echo "Starting server in debug mode"
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose up --build server
 
-start-quiet: ## Starting server in mode quiet
+start-quiet: ## Starting server container in mode quiet
 	@echo "Starting server in quiet mode"
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose up -d --build server
 
-stop: ## Stoping server
+.PHONY: exec
+exec : ## Running server container
+	@echo docker exec $(CONTAINER_NAME) $(RUN_ARGS)
+
+stop: ## Stoping server container
 	@echo "Stoping server"
 	docker-compose stop server
 
-test: ## Runing tests on server
+test: ## Runing tests on server container
 	@echo "Testing server"
-	pnpm jest
+	pnpm test
 
 prettier: ## Starting checking with prettier
 	@echo "Checking with prettier"

--- a/server/Makefile
+++ b/server/Makefile
@@ -16,7 +16,7 @@ hard-install: ## Installing hard server dependencies
 	@echo "Hard installing dependencies server"
 	rm -rf node_modules
 	rm -rf pnpm-lock.yaml
-	pnpm install
+	make install
 
 build: ## Compiling typescript
 	@echo "Building typescript on server"
@@ -38,7 +38,7 @@ stop: ## Stoping server container
 	@echo "Stoping server"
 	docker-compose stop server
 
-test: ## Runing tests on server container
+test: ## Runing tests on server
 	@echo "Testing server"
 	pnpm test
 

--- a/server/package.json
+++ b/server/package.json
@@ -9,8 +9,8 @@
 		"migration:run": "typeorm-ts-node-esm migration:run -d ./src/db.ts",
 		"start": "node dist/index.js",
 		"start:watch": "tsc -w & nodemon dist/index.js",
-		"test": "jest --runInBand",
-		"test:watch": "jest --watchAll --runInBand"
+		"test": "jest",
+		"test:watch": "jest --watchAll"
 	},
 	"dependencies": {
 		"apollo-server": "3.11.1",


### PR DESCRIPTION
## Ticket

**Title:** ETQ Dev, j’ai un command Makefile to execute commands dans Docker Container
**Notion Link:** https://www.notion.so/jkergal/ETQ-Dev-j-ai-un-command-Makefile-to-execute-commands-dans-Docker-Container-b5916c5173134b9087d342e8b95b786e

## Description

- Included make install in client Makefile.
- Included "postgres-test" on make stop in database Makefile.
- Removed PHONYs in client Makefile.
- Included make help in client Makefile.
- Included make exec in server and client Makefile.

## Guidelines

🔗 Link your PRs to their related Notion tickets
✍️ Use the commit convention to your pull request title
📃 If your code affects the build, update `README.md`
🚫 Do not merge a PR until all comments are resolved
🗑 Remove your branch after merging
