### PR TITLE
refactor(server): refactoring member resolver mutations

### DIFF
--- a/server/.prettierignore
+++ b/server/.prettierignore
@@ -12,3 +12,7 @@ coverage
 
 # Ignore test coverage reports:
 **/coverage/**
+
+
+# Ignore .pnpm-store files:
+.pnpm-store/**

--- a/server/src/entities/Session.ts
+++ b/server/src/entities/Session.ts
@@ -15,7 +15,7 @@ export default class Session {
 	@IsHexadecimal()
 	token: string;
 
-	@ManyToOne(() => Member, { eager: true })
+	@ManyToOne(() => Member, { eager: true, onDelete: 'CASCADE' })
 	@Field()
 	member: Member;
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,6 +3,8 @@ import { ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core';
 import { buildSchema } from 'type-graphql';
 
 import MemberResolver from 'resolvers/MemberResolver';
+import RoutingTokenResolver from 'resolvers/RoutingTokenResolver';
+
 import MemberServices from 'services/MemberServices';
 
 import { GlobalContext } from 'utils/types/GlobalContext';
@@ -14,13 +16,14 @@ const startServer = async () => {
 
 	const server = new ApolloServer({
 		schema: await buildSchema({
-			resolvers: [MemberResolver],
-			authChecker: ({ context }) => {
+			resolvers: [MemberResolver, RoutingTokenResolver],
+			authChecker: async ({ context }) => {
 				return Boolean(context.user);
 			}
 		}),
 		context: async (context): Promise<GlobalContext> => {
 			const token = Cookie.getSessionToken(context);
+
 			const user = !token ? null : await MemberServices.findBySessionToken(token);
 
 			return { res: context.res, req: context.req, user };

--- a/server/src/resolvers/MemberResolver.ts
+++ b/server/src/resolvers/MemberResolver.ts
@@ -70,8 +70,12 @@ export default class MemberResolver {
 
 	@Authorized()
 	@Mutation(() => Member)
-	async updatePassword(@Args() { password, email }: UpdatePasswordArgs): Promise<Member> {
-		return MemberServices.updatePassword(email, password);
+	async updatePassword(@Args() { new_password, confirm_password, old_password }: UpdatePasswordArgs, @Ctx() context: GlobalContext): Promise<Member> {
+		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string)
+
+		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
+
+		return MemberServices.updatePassword(user.email, new_password, confirm_password, old_password);
 	}
 
 	@Authorized()

--- a/server/src/resolvers/MemberResolver.ts
+++ b/server/src/resolvers/MemberResolver.ts
@@ -78,7 +78,12 @@ export default class MemberResolver {
 		@Args() { new_password, confirm_password, old_password }: UpdatePasswordArgs,
 		@Ctx() context: GlobalContext
 	): Promise<Member> {
-		return MemberServices.updatePassword(context.user?.email as string, new_password, confirm_password, old_password);
+		return MemberServices.updatePassword(
+			context.user?.email as string,
+			new_password,
+			confirm_password,
+			old_password
+		);
 	}
 
 	@Authorized()

--- a/server/src/resolvers/MemberResolver.ts
+++ b/server/src/resolvers/MemberResolver.ts
@@ -30,7 +30,7 @@ export default class MemberResolver {
 	}
 	@Mutation(() => Member)
 	async signUp(@Args() { username, email, password }: SignUpArgs): Promise<Member> {
-		const { user } = await MemberServices.signUp(username, email, password);
+		const user = MemberServices.signUp(username, email, password);
 
 		return user;
 	}
@@ -71,12 +71,12 @@ export default class MemberResolver {
 	@Authorized()
 	@Mutation(() => Member)
 	async updatePassword(@Args() { password, email }: UpdatePasswordArgs): Promise<Member> {
-		return await MemberServices.updatePassword(email, password);
+		return MemberServices.updatePassword(email, password);
 	}
 
 	@Authorized()
 	@Mutation(() => Member)
 	async deleteAccount(@Args() { password, id }: DeleteAccountArgs): Promise<Member> {
-		return await MemberServices.deleteAccount(id, password);
+		return MemberServices.deleteAccount(id, password);
 	}
 }

--- a/server/src/resolvers/MemberResolver.ts
+++ b/server/src/resolvers/MemberResolver.ts
@@ -50,12 +50,15 @@ export default class MemberResolver {
 
 	@Authorized()
 	@Mutation(() => Member)
-	async updateUsername(@Args() { username }: UpdateUsernameArgs, @Ctx() context: GlobalContext): Promise<Member> {
+	async updateUsername(
+		@Args() { username }: UpdateUsernameArgs,
+		@Ctx() context: GlobalContext
+	): Promise<Member> {
 		const username_registered = (await MemberServices.findOneBy({ username })) as Member;
 
 		if (username_registered) throw Error(ErrorMessages.USERNAME_ALREADY_REGISTERED_ERROR_MESSAGE);
 
-		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string)
+		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string);
 
 		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
 
@@ -64,12 +67,15 @@ export default class MemberResolver {
 
 	@Authorized()
 	@Mutation(() => Member)
-	async updateEmail(@Args() { email }: UpdateEmailArgs, @Ctx() context: GlobalContext): Promise<Member> {
+	async updateEmail(
+		@Args() { email }: UpdateEmailArgs,
+		@Ctx() context: GlobalContext
+	): Promise<Member> {
 		const email_registered = (await MemberServices.findOneBy({ email })) as Member;
 
 		if (email_registered) throw Error(ErrorMessages.EMAIL_ALREADY_REGISTERED_ERROR_MESSAGE);
 
-		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string)
+		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string);
 
 		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
 
@@ -78,8 +84,11 @@ export default class MemberResolver {
 
 	@Authorized()
 	@Mutation(() => Member)
-	async updatePassword(@Args() { new_password, confirm_password, old_password }: UpdatePasswordArgs, @Ctx() context: GlobalContext): Promise<Member> {
-		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string)
+	async updatePassword(
+		@Args() { new_password, confirm_password, old_password }: UpdatePasswordArgs,
+		@Ctx() context: GlobalContext
+	): Promise<Member> {
+		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string);
 
 		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
 
@@ -88,8 +97,11 @@ export default class MemberResolver {
 
 	@Authorized()
 	@Mutation(() => Member)
-	async deleteAccount(@Args() { password }: DeleteAccountArgs, @Ctx() context: GlobalContext): Promise<Member> {
-		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string)
+	async deleteAccount(
+		@Args() { password }: DeleteAccountArgs,
+		@Ctx() context: GlobalContext
+	): Promise<Member> {
+		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string);
 
 		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
 

--- a/server/src/resolvers/MemberResolver.ts
+++ b/server/src/resolvers/MemberResolver.ts
@@ -50,22 +50,30 @@ export default class MemberResolver {
 
 	@Authorized()
 	@Mutation(() => Member)
-	async updateUsername(@Args() { username, id }: UpdateUsernameArgs): Promise<Member> {
-		const user = (await MemberServices.findOneBy({ username })) as Member;
+	async updateUsername(@Args() { username }: UpdateUsernameArgs, @Ctx() context: GlobalContext): Promise<Member> {
+		const username_registered = (await MemberServices.findOneBy({ username })) as Member;
 
-		if (user) throw Error(ErrorMessages.USERNAME_ALREADY_REGISTERED_ERROR_MESSAGE);
+		if (username_registered) throw Error(ErrorMessages.USERNAME_ALREADY_REGISTERED_ERROR_MESSAGE);
 
-		return await MemberServices.updateUsername(id, username);
+		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string)
+
+		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
+
+		return await MemberServices.updateUsername(user.id, username);
 	}
 
 	@Authorized()
 	@Mutation(() => Member)
-	async updateEmail(@Args() { email, id }: UpdateEmailArgs): Promise<Member> {
-		const user = (await MemberServices.findOneBy({ email })) as Member;
+	async updateEmail(@Args() { email }: UpdateEmailArgs, @Ctx() context: GlobalContext): Promise<Member> {
+		const email_registered = (await MemberServices.findOneBy({ email })) as Member;
 
-		if (user) throw Error(ErrorMessages.EMAIL_ALREADY_REGISTERED_ERROR_MESSAGE);
+		if (email_registered) throw Error(ErrorMessages.EMAIL_ALREADY_REGISTERED_ERROR_MESSAGE);
 
-		return await MemberServices.updateEmail(id, email);
+		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string)
+
+		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
+
+		return await MemberServices.updateEmail(user.id, email);
 	}
 
 	@Authorized()
@@ -80,7 +88,11 @@ export default class MemberResolver {
 
 	@Authorized()
 	@Mutation(() => Member)
-	async deleteAccount(@Args() { password, id }: DeleteAccountArgs): Promise<Member> {
-		return MemberServices.deleteAccount(id, password);
+	async deleteAccount(@Args() { password }: DeleteAccountArgs, @Ctx() context: GlobalContext): Promise<Member> {
+		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string)
+
+		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
+
+		return MemberServices.deleteAccount(user.id, password);
 	}
 }

--- a/server/src/resolvers/MemberResolver.ts
+++ b/server/src/resolvers/MemberResolver.ts
@@ -26,21 +26,18 @@ export default class MemberResolver {
 		const { user, session } = await MemberServices.signIn(email, password);
 
 		Cookie.setSessionToken(context, session.token);
+
 		return user;
 	}
 	@Mutation(() => Member)
 	async signUp(@Args() { username, email, password }: SignUpArgs): Promise<Member> {
-		const user = MemberServices.signUp(username, email, password);
-
-		return user;
+		return MemberServices.signUp(username, email, password);
 	}
 
 	@Authorized()
 	@Mutation(() => Boolean)
 	async signOut(@Ctx() context: GlobalContext): Promise<any> {
-		const token = Cookie.getSessionToken(context) as string;
-
-		return await MemberServices.signOut(token);
+		return await MemberServices.signOut(Cookie.getSessionToken(context) as string);
 	}
 
 	@Authorized()
@@ -59,11 +56,7 @@ export default class MemberResolver {
 
 		if (username_registered) throw Error(ErrorMessages.USERNAME_ALREADY_REGISTERED_ERROR_MESSAGE);
 
-		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string);
-
-		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
-
-		return await MemberServices.updateUsername(user.id, username);
+		return await MemberServices.updateUsername(context.user?.id as string, username);
 	}
 
 	@Authorized()
@@ -76,11 +69,7 @@ export default class MemberResolver {
 
 		if (email_registered) throw Error(ErrorMessages.EMAIL_ALREADY_REGISTERED_ERROR_MESSAGE);
 
-		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string);
-
-		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
-
-		return await MemberServices.updateEmail(user.id, email);
+		return await MemberServices.updateEmail(context.user?.id as string, email);
 	}
 
 	@Authorized()
@@ -89,11 +78,7 @@ export default class MemberResolver {
 		@Args() { new_password, confirm_password, old_password }: UpdatePasswordArgs,
 		@Ctx() context: GlobalContext
 	): Promise<Member> {
-		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string);
-
-		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
-
-		return MemberServices.updatePassword(user.email, new_password, confirm_password, old_password);
+		return MemberServices.updatePassword(context.user?.email as string, new_password, confirm_password, old_password);
 	}
 
 	@Authorized()
@@ -102,10 +87,6 @@ export default class MemberResolver {
 		@Args() { password }: DeleteAccountArgs,
 		@Ctx() context: GlobalContext
 	): Promise<Member> {
-		const user = await MemberServices.findBySessionToken(Cookie.getSessionToken(context) as string);
-
-		if (!user) throw Error(ErrorMessages.INVALID_CREDENTIALS_ERROR_MESSAGE);
-
-		return MemberServices.deleteAccount(user.id, password);
+		return MemberServices.deleteAccount(context.user?.id as string, password);
 	}
 }

--- a/server/src/resolvers/MemberResolver.ts
+++ b/server/src/resolvers/MemberResolver.ts
@@ -35,11 +35,12 @@ export default class MemberResolver {
 		return user;
 	}
 
+	@Authorized()
 	@Mutation(() => Boolean)
 	async signOut(@Ctx() context: GlobalContext): Promise<any> {
 		const token = Cookie.getSessionToken(context) as string;
 
-		await MemberServices.signOut(token);
+		return await MemberServices.signOut(token);
 	}
 
 	@Authorized()

--- a/server/src/resolvers/RoutingTokenResolver.ts
+++ b/server/src/resolvers/RoutingTokenResolver.ts
@@ -28,12 +28,12 @@ export default class MemberResolver {
 	}
 
 	@Mutation(() => Member)
-	async resetPassword(@Args() { token, password }: ResetPasswordArgs): Promise<Member> {
+	async resetPassword(@Args() { token, new_password, confirm_password, old_password }: ResetPasswordArgs): Promise<Member> {
 		const routingToken = (await RoutingTokenServices.findByToken(token)) as RoutingToken;
 
 		if (!routingToken) throw Error(ErrorMessages.INVALID_TOKEN_ERROR_MESSAGE);
 
-		return await MemberServices.updatePassword(routingToken.email, password);
+		return await MemberServices.updatePassword(routingToken.email, new_password, confirm_password, old_password);
 	}
 
 	@Mutation(() => RoutingToken)

--- a/server/src/resolvers/RoutingTokenResolver.ts
+++ b/server/src/resolvers/RoutingTokenResolver.ts
@@ -29,18 +29,13 @@ export default class MemberResolver {
 
 	@Mutation(() => Member)
 	async resetPassword(
-		@Args() { token, new_password, confirm_password, old_password }: ResetPasswordArgs
+		@Args() { token, newPassword, confirmPassword }: ResetPasswordArgs
 	): Promise<Member> {
 		const routingToken = (await RoutingTokenServices.findByToken(token)) as RoutingToken;
 
 		if (!routingToken) throw Error(ErrorMessages.INVALID_TOKEN_ERROR_MESSAGE);
 
-		return await MemberServices.updatePassword(
-			routingToken.email,
-			new_password,
-			confirm_password,
-			old_password
-		);
+		return await MemberServices.updatePassword(routingToken.email, newPassword, confirmPassword);
 	}
 
 	@Mutation(() => RoutingToken)

--- a/server/src/resolvers/RoutingTokenResolver.ts
+++ b/server/src/resolvers/RoutingTokenResolver.ts
@@ -28,12 +28,19 @@ export default class MemberResolver {
 	}
 
 	@Mutation(() => Member)
-	async resetPassword(@Args() { token, new_password, confirm_password, old_password }: ResetPasswordArgs): Promise<Member> {
+	async resetPassword(
+		@Args() { token, new_password, confirm_password, old_password }: ResetPasswordArgs
+	): Promise<Member> {
 		const routingToken = (await RoutingTokenServices.findByToken(token)) as RoutingToken;
 
 		if (!routingToken) throw Error(ErrorMessages.INVALID_TOKEN_ERROR_MESSAGE);
 
-		return await MemberServices.updatePassword(routingToken.email, new_password, confirm_password, old_password);
+		return await MemberServices.updatePassword(
+			routingToken.email,
+			new_password,
+			confirm_password,
+			old_password
+		);
 	}
 
 	@Mutation(() => RoutingToken)

--- a/server/src/resolvers/args/MemberArgs.ts
+++ b/server/src/resolvers/args/MemberArgs.ts
@@ -48,15 +48,15 @@ export class UpdateEmailArgs {
 export class UpdatePasswordArgs {
 	@Field()
 	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
-	new_password: string;
+	newPassword: string;
 
 	@Field()
 	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
-	confirm_password: string;
+	confirmPassword: string;
 
 	@Field()
 	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
-	old_password: string;
+	oldPassword: string;
 }
 
 @ArgsType()

--- a/server/src/resolvers/args/MemberArgs.ts
+++ b/server/src/resolvers/args/MemberArgs.ts
@@ -54,11 +54,15 @@ export class UpdateEmailArgs {
 export class UpdatePasswordArgs {
 	@Field()
 	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
-	password: string;
+	new_password: string;
 
 	@Field()
-	@IsEmail()
-	email: string;
+	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
+	confirm_password: string;
+
+	@Field()
+	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
+	old_password: string;
 }
 
 @ArgsType()

--- a/server/src/resolvers/args/MemberArgs.ts
+++ b/server/src/resolvers/args/MemberArgs.ts
@@ -35,9 +35,6 @@ export class UpdateUsernameArgs {
 	@Field()
 	@MinLength(3, { message: ErrorMessages.USERNAME_MUST_BE_LONG_ERROR_MESSAGE })
 	username: string;
-
-	@Field()
-	id: string;
 }
 
 @ArgsType()
@@ -45,9 +42,6 @@ export class UpdateEmailArgs {
 	@Field()
 	@IsEmail()
 	email: string;
-
-	@Field()
-	id: string;
 }
 
 @ArgsType()
@@ -70,7 +64,4 @@ export class DeleteAccountArgs {
 	@Field()
 	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
 	password: string;
-
-	@Field()
-	id: string;
 }

--- a/server/src/resolvers/args/RoutingTokenArgs.ts
+++ b/server/src/resolvers/args/RoutingTokenArgs.ts
@@ -16,7 +16,15 @@ export class ForgotPasswordArgs {
 export class ResetPasswordArgs {
 	@Field()
 	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
-	password: string;
+	new_password: string;
+
+	@Field()
+	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
+	confirm_password: string;
+
+	@Field()
+	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
+	old_password: string;
 
 	@Field()
 	token: string;

--- a/server/src/resolvers/args/RoutingTokenArgs.ts
+++ b/server/src/resolvers/args/RoutingTokenArgs.ts
@@ -16,15 +16,11 @@ export class ForgotPasswordArgs {
 export class ResetPasswordArgs {
 	@Field()
 	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
-	new_password: string;
+	newPassword: string;
 
 	@Field()
 	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
-	confirm_password: string;
-
-	@Field()
-	@Matches(passwordRegExp, { message: ErrorMessages.PASSWORD_FORMAT_ERROR_MESSAGE })
-	old_password: string;
+	confirmPassword: string;
 
 	@Field()
 	token: string;

--- a/server/src/services/MemberServices.ts
+++ b/server/src/services/MemberServices.ts
@@ -60,14 +60,21 @@ class MemberServices extends BaseServices {
 		return await this.update(id, { isValidEmail: true });
 	}
 
-	async updatePassword(email: string, new_password: string, confirm_passsword: string, old_password: string) {
+	async updatePassword(
+		email: string,
+		new_password: string,
+		confirm_passsword: string,
+		old_password: string
+	) {
 		const user = (await this.findOneBy({ email })) as Member;
 
 		if (!user) throw Error(ErrorMessages.INVALID_EMAIL_ERROR_MESSAGE);
 
-		if (new_password !== confirm_passsword) throw Error(ErrorMessages.PASSWORDS_DO_NOT_MATCH_ERROR_MESSAGE);
+		if (new_password !== confirm_passsword)
+			throw Error(ErrorMessages.PASSWORDS_DO_NOT_MATCH_ERROR_MESSAGE);
 
-		if (!compareSync(old_password, user.hashedPassword)) throw Error(ErrorMessages.INVALID_PASSWORD_ERROR_MESSAGE);
+		if (!compareSync(old_password, user.hashedPassword))
+			throw Error(ErrorMessages.INVALID_PASSWORD_ERROR_MESSAGE);
 
 		const hashedPassword = hashSync(new_password, 10);
 

--- a/server/src/services/MemberServices.ts
+++ b/server/src/services/MemberServices.ts
@@ -60,12 +60,16 @@ class MemberServices extends BaseServices {
 		return await this.update(id, { isValidEmail: true });
 	}
 
-	async updatePassword(email: string, password: string) {
+	async updatePassword(email: string, new_password: string, confirm_passsword: string, old_password: string) {
 		const user = (await this.findOneBy({ email })) as Member;
 
 		if (!user) throw Error(ErrorMessages.INVALID_EMAIL_ERROR_MESSAGE);
 
-		const hashedPassword = hashSync(password, 10);
+		if (new_password !== confirm_passsword) throw Error(ErrorMessages.PASSWORDS_DO_NOT_MATCH_ERROR_MESSAGE);
+
+		if (!compareSync(old_password, user.hashedPassword)) throw Error(ErrorMessages.INVALID_PASSWORD_ERROR_MESSAGE);
+
+		const hashedPassword = hashSync(new_password, 10);
 
 		return await this.update(user.id, { hashedPassword });
 	}

--- a/server/src/services/MemberServices.ts
+++ b/server/src/services/MemberServices.ts
@@ -60,23 +60,15 @@ class MemberServices extends BaseServices {
 		return await this.update(id, { isValidEmail: true });
 	}
 
-	async updatePassword(
-		email: string,
-		new_password: string,
-		confirm_passsword: string,
-		old_password: string
-	) {
+	async updatePassword(email: string, newPassword: string, confirmPasssword: string) {
 		const user = (await this.findOneBy({ email })) as Member;
 
 		if (!user) throw Error(ErrorMessages.INVALID_EMAIL_ERROR_MESSAGE);
 
-		if (new_password !== confirm_passsword)
+		if (newPassword !== confirmPasssword)
 			throw Error(ErrorMessages.PASSWORDS_DO_NOT_MATCH_ERROR_MESSAGE);
 
-		if (!compareSync(old_password, user.hashedPassword))
-			throw Error(ErrorMessages.INVALID_PASSWORD_ERROR_MESSAGE);
-
-		const hashedPassword = hashSync(new_password, 10);
+		const hashedPassword = hashSync(newPassword, 10);
 
 		return await this.update(user.id, { hashedPassword });
 	}

--- a/server/src/utils/enums/ErrorMessages.ts
+++ b/server/src/utils/enums/ErrorMessages.ts
@@ -13,6 +13,7 @@ export enum ErrorMessages {
 	INVALID_USERNAME_ERROR_MESSAGE = 'Invalid username',
 	INVALID_TOKEN_ERROR_MESSAGE = 'Invalid token',
 	EMPTY_FIELD_ERROR_MESSAGE = 'Field cannot be empty',
+	PASSWORDS_DO_NOT_MATCH_ERROR_MESSAGE = 'Passwords do not match',
 
 	// Validation exists
 	USERNAME_ALREADY_REGISTERED_ERROR_MESSAGE = 'Username is already in use',

--- a/server/src/utils/enums/Validations.ts
+++ b/server/src/utils/enums/Validations.ts
@@ -1,4 +1,4 @@
 export enum Validations {
 	PASSWORD_REGEX = '^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*])(?=.{8,})',
-	MAX_AGE_DAYS = 365
+	MAX_AGE_DAYS = 7
 }

--- a/server/src/utils/methods/Cookie.ts
+++ b/server/src/utils/methods/Cookie.ts
@@ -5,20 +5,20 @@ import { Validations } from 'utils/enums/Validations';
 export abstract class Cookie {
 	public static getSessionToken = (ctx: ExpressContext): string | undefined => {
 		const rawCookies = ctx.req.headers.cookie;
+
 		if (!rawCookies) return undefined;
 
-		const parsedCookies = parse(rawCookies);
-		return parsedCookies.token;
+		const cookies = parse(rawCookies);
+
+		return cookies.session;
 	};
 
 	public static setSessionToken = (ctx: ExpressContext, token: string) => {
-		const MAX_AGE_DAYS = Validations.MAX_AGE_DAYS;
-
-		ctx.res.cookie('SessionToken', token, {
+		ctx.res.cookie('session', token, {
 			httpOnly: true,
 			secure: true,
 			sameSite: true,
-			maxAge: 1000 * 60 * 60 * 24 * MAX_AGE_DAYS
+			maxAge: 1000 * 60 * 60 * 24 * Validations.MAX_AGE_DAYS
 		});
 	};
 }

--- a/server/tests/integrations/Authentication.integration.test.ts
+++ b/server/tests/integrations/Authentication.integration.test.ts
@@ -75,7 +75,7 @@ describe('Authentication integration test', () => {
 			});
 		});
 
-		describe.skip('when session token is valid', () => {
+		describe('when session token is valid', () => {
 			it('deletes session from database', async () => {
 				await MemberServices.signUp('username', 'user@test.com', 'password');
 
@@ -83,9 +83,7 @@ describe('Authentication integration test', () => {
 
 				await MemberServices.signOut(session.token);
 
-				const sessions = await SessionServices.findByToken(session.token);
-
-				expect(sessions).toBeNull();
+				expect(await SessionServices.findByToken(session.token)).toBeNull();
 			});
 		});
 	});

--- a/server/tests/integrations/Authentication.integration.test.ts
+++ b/server/tests/integrations/Authentication.integration.test.ts
@@ -75,7 +75,7 @@ describe('Authentication integration test', () => {
 			});
 		});
 
-		describe('when session token is valid', () => {
+		describe.skip('when session token is valid', () => {
 			it('deletes session from database', async () => {
 				await MemberServices.signUp('username', 'user@test.com', 'password');
 

--- a/server/tests/integrations/Authentication.integration.test.ts
+++ b/server/tests/integrations/Authentication.integration.test.ts
@@ -75,18 +75,18 @@ describe('Authentication integration test', () => {
 			});
 		});
 
-		// describe('when session token is valid', () => {
-		// 	it('deletes session from database', async () => {
-		// 		await MemberServices.signUp('username', 'user@test.com', 'password');
+		describe.skip('when session token is valid', () => {
+			it('deletes session from database', async () => {
+				await MemberServices.signUp('username', 'user@test.com', 'password');
 
-		// 		const { session } = await MemberServices.signIn('user@test.com', 'password');
+				const { session } = await MemberServices.signIn('user@test.com', 'password');
 
-		// 		await MemberServices.signOut(session.token);
+				await MemberServices.signOut(session.token);
 
-		// 		const sessions = await SessionServices.findByToken(session.token);
+				const sessions = await SessionServices.findByToken(session.token);
 
-		// 		expect(sessions).toBeNull();
-		// 	});
-		// });
+				expect(sessions).toBeNull();
+			});
+		});
 	});
 });

--- a/server/tests/integrations/services/BaseServices/create.integration.test.ts
+++ b/server/tests/integrations/services/BaseServices/create.integration.test.ts
@@ -2,7 +2,7 @@ import { hashSync } from 'bcryptjs';
 import { closeDatabase, dataSource, startDatabase } from 'db';
 import MemberServices from 'services/MemberServices';
 
-describe.skip('Create integration test', () => {
+describe('Create integration test', () => {
 	beforeAll(async () => {
 		await startDatabase();
 	});
@@ -21,15 +21,16 @@ describe.skip('Create integration test', () => {
 	describe('when try create an user with valid data', () => {
 		describe('when trying to create an element that already exists', () => {
 			it('throw an error not created', async () => {
-				await MemberServices.signUp('usertest', 'user@test.com', 'password');
 
 				const hashedPassword = hashSync('password', 10);
 
 				const data = {
 					username: 'usertest',
 					email: 'user@test.com',
-					password: hashedPassword
+					hashedPassword: hashedPassword
 				};
+
+				await MemberServices.signUp(data.username, data.email, data.hashedPassword);
 
 				expect(() => MemberServices.create(data)).rejects.toThrowError();
 			});
@@ -42,14 +43,14 @@ describe.skip('Create integration test', () => {
 				const data = {
 					username: 'usertest',
 					email: 'user@test.com',
-					password: hashedPassword
+					hashedPassword: hashedPassword
 				};
 
 				const created = await MemberServices.create(data);
 
 				expect(created.username).toEqual(data.username);
 				expect(created.email).toEqual(data.email);
-				expect(created.password).not.toEqual(data.password);
+				expect(created.password).not.toEqual(data.hashedPassword);
 			});
 		});
 	});

--- a/server/tests/integrations/services/BaseServices/create.integration.test.ts
+++ b/server/tests/integrations/services/BaseServices/create.integration.test.ts
@@ -21,7 +21,6 @@ describe('Create integration test', () => {
 	describe('when try create an user with valid data', () => {
 		describe('when trying to create an element that already exists', () => {
 			it('throw an error not created', async () => {
-
 				const hashedPassword = hashSync('password', 10);
 
 				const data = {

--- a/server/tests/integrations/services/MemberServices/updatePassword.integration.test.ts
+++ b/server/tests/integrations/services/MemberServices/updatePassword.integration.test.ts
@@ -32,7 +32,7 @@ describe('Update a Member password integration test', () => {
 			const newPassword = 'newPassword';
 
 			expect(() =>
-				MemberServices.updatePassword(wrong_email, newPassword, newPassword, password)
+				MemberServices.updatePassword(wrong_email, newPassword, newPassword)
 			).rejects.toThrowError(ErrorMessages.INVALID_EMAIL_ERROR_MESSAGE);
 		});
 	});
@@ -48,24 +48,8 @@ describe('Update a Member password integration test', () => {
 			const newPassword = 'newPassword';
 
 			expect(() =>
-				MemberServices.updatePassword(member.email, newPassword, password, password)
+				MemberServices.updatePassword(member.email, newPassword, password)
 			).rejects.toThrowError(ErrorMessages.PASSWORDS_DO_NOT_MATCH_ERROR_MESSAGE);
-		});
-	});
-
-	describe('when update password with valid email but the old password is invalid', () => {
-		it('throw an invalid password error', async () => {
-			const username = 'username';
-			const email = 'email@email.com';
-			const password = 'password';
-
-			const member = await MemberServices.signUp(username, email, password);
-
-			const newPassword = 'newPassword';
-
-			expect(() =>
-				MemberServices.updatePassword(member.email, newPassword, newPassword, newPassword)
-			).rejects.toThrowError(ErrorMessages.INVALID_PASSWORD_ERROR_MESSAGE);
 		});
 	});
 
@@ -79,12 +63,7 @@ describe('Update a Member password integration test', () => {
 
 			const newPassword = 'newPassword';
 
-			const updated = await MemberServices.updatePassword(
-				member.email,
-				newPassword,
-				newPassword,
-				password
-			);
+			const updated = await MemberServices.updatePassword(member.email, newPassword, newPassword);
 
 			expect(compareSync(newPassword, updated.hashedPassword)).toBeTruthy();
 		});

--- a/server/tests/integrations/services/MemberServices/updatePassword.integration.test.ts
+++ b/server/tests/integrations/services/MemberServices/updatePassword.integration.test.ts
@@ -53,6 +53,22 @@ describe('Update a Member password integration test', () => {
 		});
 	});
 
+	describe ('when update password with valid email but the old password is invalid', () => {
+		it('throw an invalid password error', async () => {
+			const username = 'username';
+			const email = 'email@email.com';
+			const password = 'password';
+
+			const member = await MemberServices.signUp(username, email, password);
+
+			const newPassword = 'newPassword';
+
+			expect(() => MemberServices.updatePassword(member.email, newPassword, newPassword, newPassword)).rejects.toThrowError(
+				ErrorMessages.INVALID_PASSWORD_ERROR_MESSAGE
+			);
+		});
+	});
+
 	describe('when update password with valid email and passwords match', () => {
 		it('return an member', async () => {
 			const username = 'username';

--- a/server/tests/integrations/services/MemberServices/updatePassword.integration.test.ts
+++ b/server/tests/integrations/services/MemberServices/updatePassword.integration.test.ts
@@ -31,13 +31,13 @@ describe('Update a Member password integration test', () => {
 			const wrong_email = 'unknown@email.com';
 			const newPassword = 'newPassword';
 
-			expect(() => MemberServices.updatePassword(wrong_email, newPassword, newPassword, password)).rejects.toThrowError(
-				ErrorMessages.INVALID_EMAIL_ERROR_MESSAGE
-			);
+			expect(() =>
+				MemberServices.updatePassword(wrong_email, newPassword, newPassword, password)
+			).rejects.toThrowError(ErrorMessages.INVALID_EMAIL_ERROR_MESSAGE);
 		});
 	});
 
-	describe ('when update password with valid email but passwords dont match', () => {
+	describe('when update password with valid email but passwords dont match', () => {
 		it('throw an passwords do not matchs error', async () => {
 			const username = 'username';
 			const email = 'email@email.com';
@@ -47,13 +47,13 @@ describe('Update a Member password integration test', () => {
 
 			const newPassword = 'newPassword';
 
-			expect(() => MemberServices.updatePassword(member.email, newPassword, password, password)).rejects.toThrowError(
-				ErrorMessages.PASSWORDS_DO_NOT_MATCH_ERROR_MESSAGE
-			);
+			expect(() =>
+				MemberServices.updatePassword(member.email, newPassword, password, password)
+			).rejects.toThrowError(ErrorMessages.PASSWORDS_DO_NOT_MATCH_ERROR_MESSAGE);
 		});
 	});
 
-	describe ('when update password with valid email but the old password is invalid', () => {
+	describe('when update password with valid email but the old password is invalid', () => {
 		it('throw an invalid password error', async () => {
 			const username = 'username';
 			const email = 'email@email.com';
@@ -63,9 +63,9 @@ describe('Update a Member password integration test', () => {
 
 			const newPassword = 'newPassword';
 
-			expect(() => MemberServices.updatePassword(member.email, newPassword, newPassword, newPassword)).rejects.toThrowError(
-				ErrorMessages.INVALID_PASSWORD_ERROR_MESSAGE
-			);
+			expect(() =>
+				MemberServices.updatePassword(member.email, newPassword, newPassword, newPassword)
+			).rejects.toThrowError(ErrorMessages.INVALID_PASSWORD_ERROR_MESSAGE);
 		});
 	});
 
@@ -79,10 +79,14 @@ describe('Update a Member password integration test', () => {
 
 			const newPassword = 'newPassword';
 
-			const updated = await MemberServices.updatePassword(member.email, newPassword, newPassword, password);
+			const updated = await MemberServices.updatePassword(
+				member.email,
+				newPassword,
+				newPassword,
+				password
+			);
 
 			expect(compareSync(newPassword, updated.hashedPassword)).toBeTruthy();
 		});
 	});
-
 });

--- a/server/tests/integrations/services/MemberServices/updatePassword.integration.test.ts
+++ b/server/tests/integrations/services/MemberServices/updatePassword.integration.test.ts
@@ -22,28 +22,51 @@ describe('Update a Member password integration test', () => {
 
 	describe('when update password with invalid email', () => {
 		it('throw an invalid email error', async () => {
-			const email = 'unknown@email.com';
+			const username = 'username';
+			const email = 'email@email.com';
+			const password = 'password';
+
+			await MemberServices.signUp(username, email, password);
+
+			const wrong_email = 'unknown@email.com';
 			const newPassword = 'newPassword';
 
-			expect(() => MemberServices.updatePassword(email, newPassword)).rejects.toThrowError(
+			expect(() => MemberServices.updatePassword(wrong_email, newPassword, newPassword, password)).rejects.toThrowError(
 				ErrorMessages.INVALID_EMAIL_ERROR_MESSAGE
 			);
 		});
 	});
 
-	describe('when update password with valid email', () => {
-		it('return an member', async () => {
+	describe ('when update password with valid email but passwords dont match', () => {
+		it('throw an passwords do not matchs error', async () => {
 			const username = 'username';
-			const email = 'unknown@email.com';
+			const email = 'email@email.com';
 			const password = 'password';
 
 			const member = await MemberServices.signUp(username, email, password);
 
 			const newPassword = 'newPassword';
 
-			const updated = await MemberServices.updatePassword(member.email, newPassword);
+			expect(() => MemberServices.updatePassword(member.email, newPassword, password, password)).rejects.toThrowError(
+				ErrorMessages.PASSWORDS_DO_NOT_MATCH_ERROR_MESSAGE
+			);
+		});
+	});
+
+	describe('when update password with valid email and passwords match', () => {
+		it('return an member', async () => {
+			const username = 'username';
+			const email = 'email@email.com';
+			const password = 'password';
+
+			const member = await MemberServices.signUp(username, email, password);
+
+			const newPassword = 'newPassword';
+
+			const updated = await MemberServices.updatePassword(member.email, newPassword, newPassword, password);
 
 			expect(compareSync(newPassword, updated.hashedPassword)).toBeTruthy();
 		});
 	});
+
 });


### PR DESCRIPTION
## Ticket

**Title:** ETQ Dev, j’ai refactor MemberResolver to include getSessionToken by Cookie et validation dans le updatePassword
**Notion Link:** https://www.notion.so/jkergal/ETQ-Dev-j-ai-refactor-MemberResolver-to-include-getSessionToken-by-Cookie-et-validation-dans-le-upd-0aa30b1d7b744e459cf8c1371e599e93

## Description

- Including getSessionToken by Cookie on mutations that require ID, like updates and delete. 
- Including validation of passwords on updatePassword method.
- Update test on create method.

## Guidelines

🔗 Link your PRs to their related Notion tickets
✍️ Use the commit convention to your pull request title
📃 If your code affects the build, update `README.md`
🚫 Do not merge a PR until all comments are resolved
🗑 Remove your branch after merging
