### PR TITLE
test(server): add mock to console.log o hide the log error expected by test

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -21,7 +21,7 @@ const dataSource = new DataSource({
 const startDatabase = async function () {
 	try {
 		await dataSource.initialize();
-		console.log('🎉 Successfully connected to database');
+		console.info('🎉 Successfully connected to database');
 	} catch (error) {
 		console.log('😞 Database connection error');
 		console.log(error);
@@ -31,7 +31,7 @@ const startDatabase = async function () {
 const closeDatabase = async function () {
 	try {
 		await dataSource.destroy();
-		console.log('💀 Successfully disconnected to database');
+		console.info('💀 Successfully disconnected to database');
 	} catch (error) {
 		console.log('😞 Database disconnection error');
 		console.log(error);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -35,6 +35,6 @@ const startServer = async () => {
 
 	const { url } = await server.listen(process.env.GRAPHQL_PORT);
 
-	console.log(`🚀 Server ready at ${url}`);
+	console.info(`🚀 Server ready at ${url}`);
 };
 startServer();

--- a/server/tests/integrations/Authentication.integration.test.ts
+++ b/server/tests/integrations/Authentication.integration.test.ts
@@ -7,6 +7,7 @@ import { randomBytes } from 'crypto';
 
 describe('Authentication integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/BaseServices/create.integration.test.ts
+++ b/server/tests/integrations/services/BaseServices/create.integration.test.ts
@@ -20,6 +20,10 @@ describe('Create integration test', () => {
 
 	describe('when try create an user with valid data', () => {
 		describe('when trying to create an element that already exists', () => {
+			beforeEach(() => {
+				jest.spyOn(console, 'log').mockImplementation(() => {});
+			});
+
 			it('throw an error not created', async () => {
 				const hashedPassword = hashSync('password', 10);
 

--- a/server/tests/integrations/services/BaseServices/create.integration.test.ts
+++ b/server/tests/integrations/services/BaseServices/create.integration.test.ts
@@ -4,6 +4,7 @@ import MemberServices from 'services/MemberServices';
 
 describe('Create integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/BaseServices/delete.integration.test.ts
+++ b/server/tests/integrations/services/BaseServices/delete.integration.test.ts
@@ -5,6 +5,7 @@ import { v4 as uuid } from 'uuid';
 
 describe('Delete integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/BaseServices/find.integration.test.ts
+++ b/server/tests/integrations/services/BaseServices/find.integration.test.ts
@@ -3,6 +3,7 @@ import MemberServices from 'services/MemberServices';
 
 describe('Find integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/BaseServices/findBy.integration.test.ts
+++ b/server/tests/integrations/services/BaseServices/findBy.integration.test.ts
@@ -3,6 +3,7 @@ import MemberServices from 'services/MemberServices';
 
 describe('FindBy integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/BaseServices/findById.integration.test.ts
+++ b/server/tests/integrations/services/BaseServices/findById.integration.test.ts
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid';
 
 describe('FindById integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/BaseServices/findOneBy.integration.test.ts
+++ b/server/tests/integrations/services/BaseServices/findOneBy.integration.test.ts
@@ -3,6 +3,7 @@ import MemberServices from 'services/MemberServices';
 
 describe('FindOneBy integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/BaseServices/update.integration.test.ts
+++ b/server/tests/integrations/services/BaseServices/update.integration.test.ts
@@ -5,6 +5,7 @@ import { v4 as uuid } from 'uuid';
 
 describe('Update integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/MemberServices/deleteAccount.integration.test.ts
+++ b/server/tests/integrations/services/MemberServices/deleteAccount.integration.test.ts
@@ -5,6 +5,7 @@ import { ErrorMessages } from 'utils/enums/ErrorMessages';
 
 describe('Delete a Member account integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/MemberServices/findBySessionToken.integration.test.ts
+++ b/server/tests/integrations/services/MemberServices/findBySessionToken.integration.test.ts
@@ -5,6 +5,7 @@ import { randomBytes } from 'crypto';
 
 describe('Find a Member by session token integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/MemberServices/signUp.integration.test.ts
+++ b/server/tests/integrations/services/MemberServices/signUp.integration.test.ts
@@ -5,6 +5,7 @@ import { ErrorMessages } from 'utils/enums/ErrorMessages';
 
 describe('Singup a Member integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/MemberServices/updateEmail.integration.test.ts
+++ b/server/tests/integrations/services/MemberServices/updateEmail.integration.test.ts
@@ -4,6 +4,7 @@ import { dataSource, closeDatabase, startDatabase } from 'db';
 
 describe('Update a Member email integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/MemberServices/updatePassword.integration.test.ts
+++ b/server/tests/integrations/services/MemberServices/updatePassword.integration.test.ts
@@ -6,6 +6,7 @@ import { ErrorMessages } from 'utils/enums/ErrorMessages';
 
 describe('Update a Member password integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/MemberServices/updateUsername.integration.test.ts
+++ b/server/tests/integrations/services/MemberServices/updateUsername.integration.test.ts
@@ -4,6 +4,7 @@ import { dataSource, closeDatabase, startDatabase } from 'db';
 
 describe('Update a Member username integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/MemberServices/validEmail.integration.test.ts
+++ b/server/tests/integrations/services/MemberServices/validEmail.integration.test.ts
@@ -4,6 +4,7 @@ import { dataSource, closeDatabase, startDatabase } from 'db';
 
 describe('Validate a Member email integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/RoutingTokensServices/create.integration.test.ts
+++ b/server/tests/integrations/services/RoutingTokensServices/create.integration.test.ts
@@ -5,6 +5,7 @@ import { dataSource, closeDatabase, startDatabase } from 'db';
 
 describe('Create RoutingToken integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/RoutingTokensServices/findByToken.integration.test.ts
+++ b/server/tests/integrations/services/RoutingTokensServices/findByToken.integration.test.ts
@@ -5,6 +5,7 @@ import { dataSource, closeDatabase, startDatabase } from 'db';
 
 describe('Find a RoutingToken ByToken integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 

--- a/server/tests/integrations/services/SessionServices/delete.integration.test.ts
+++ b/server/tests/integrations/services/SessionServices/delete.integration.test.ts
@@ -7,6 +7,7 @@ import { randomBytes } from 'crypto';
 
 describe('Delete Session integration test', () => {
 	beforeAll(async () => {
+		jest.spyOn(console, 'info').mockImplementation(() => {});
 		await startDatabase();
 	});
 


### PR DESCRIPTION
## Ticket

**Title:** ETQ Dev, j’ai des tests qui ne montre pas les consoles logs qui viens des errors expecteds par les tests ou consoles infos qui viens par default du server
**Notion Link:** https://www.notion.so/jkergal/ETQ-Dev-j-ai-des-tests-qui-ne-montre-pas-les-consoles-logs-qui-viens-des-errors-expecteds-par-les-t-68f61936c6f748fea7227247a0e54ee2

## Description

- Added beforeEach to mock console.log before the create.integration.test
- Added mock on console.info before all tests to hide the info about successfully connection or disconnection with the database.

## Guidelines

🔗 Link your PRs to their related Notion tickets
✍️ Use the commit convention to your pull request title
📃 If your code affects the build, update `README.md`
🚫 Do not merge a PR until all comments are resolved
🗑 Remove your branch after merging
