### PR TITLE
build(ci): start ci when convert pr draft to ready for review

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/workflows/client.yml'
       - 'client/**'
+    types: [ready_for_review]
 
 env:
   SERVICE_NAME: 'client'

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/workflows/server.yml'
       - 'server/**'
+    types: [ready_for_review]
 
 env:
   SERVICE_NAME: 'server'


### PR DESCRIPTION
## Ticket

**Title:** [BUG] - ETQ Dev, j’ai la CI qui se déclenche correctement lorsque je met ma PR en “ready to be reviewed”
**Notion Link:** https://www.notion.so/jkergal/BUG-ETQ-Dev-j-ai-la-CI-qui-se-d-clenche-correctement-lorsque-je-met-ma-PR-en-ready-to-be-review-a4457da7cbd04dc4aeae22a5d31ddbe8?pvs=4

## Description
- Include pull_request types on CI

## Guidelines

🔗 Link your PRs to their related Notion tickets
✍️ Use the commit convention to your pull request title
📃 If your code affects the build, update `README.md`
🚫 Do not merge a PR until all comments are resolved
🗑 Remove your branch after merging
