### PR TITLE
fix: returning boolean when delete member account

### DIFF
--- a/client/src/pages/account/account.graphql.ts
+++ b/client/src/pages/account/account.graphql.ts
@@ -37,10 +37,6 @@ export const UPDATE_USERNAME_MUTATION = gql`
 
 export const DELETE_ACCOUNT_MUTATION = gql`
 	mutation DeleteAccount($password: String!) {
-		deleteMemberAccount(password: $password) {
-			id
-			email
-			username
-		}
+		deleteMemberAccount(password: $password)
 	}
 `;

--- a/server/src/resolvers/MemberResolver.ts
+++ b/server/src/resolvers/MemberResolver.ts
@@ -133,7 +133,7 @@ export class MemberResolver {
 	}
 
 	@Authorized()
-	@Mutation(() => Member)
+	@Mutation(() => Boolean)
 	async deleteMemberAccount(
 		@Args() { password }: DeleteMemberAccountArgs,
 		@Ctx() context: GlobalContext


### PR DESCRIPTION
## Ticket

**Title:** [BUG] Impossible de supprimer son compte
**Notion Link:** https://www.notion.so/jkergal/BUG-Impossible-de-supprimer-son-compte-4b50159fd2da4b8fbc56c049b568aaad?pvs=4

## Description

- Update  `deleteMemberAccount` returns type on `MemberResolver` from `Member` to  `Boolean`.
- Update `DELETE_ACCOUNT_MUTATION `on `account.graphql` to remove all properties asked.

Closes #93 

## Guidelines

🔗 Link your PRs to their related Notion tickets
✍️ Use the commit convention to your pull request title
📃 If your code affects the build, update `README.md`
🚫 Do not merge a PR until all comments are resolved
🗑 Remove your branch after merging
