### PR TITLE
fix(client): set new mainFile when delete the old mainFile

### DIFF
--- a/client/src/pages/code/_components/custom-file-explorer.tsx
+++ b/client/src/pages/code/_components/custom-file-explorer.tsx
@@ -69,10 +69,12 @@ export const CustomFileExplorer = ({ className, files }: CustomFileExplorerProps
 				handleRenameStart(selectedNode, event);
 			}
 			if (action === 'delete' && selectedNode !== null) {
-				if (selectedNode.path === currentProjectData?.main)
-					return toast.error('You cannot delete the main file of your project', {
-						autoClose: 10000
-					});
+				if (selectedNode.path === currentProjectData?.main) {
+					const arrayOfMainFile = Object.keys(currentProjectData?.files).filter(
+						(file) => file !== selectedNode.path
+					);
+					currentProjectData.main = arrayOfMainFile[0];
+				}
 				sandpack.deleteFile(selectedNode.path);
 			}
 		};

--- a/client/src/pages/my-projects/_components/filter-bar.tsx
+++ b/client/src/pages/my-projects/_components/filter-bar.tsx
@@ -21,7 +21,6 @@ export const FilterBar = ({ className, state }: FilterBarProps) => {
 	};
 
 	const handleOnChange = (searchText: string) => {
-		console.log({ searchText });
 		state.setInputSearch(searchText);
 	};
 
@@ -40,7 +39,6 @@ export const FilterBar = ({ className, state }: FilterBarProps) => {
 
 	useEffect(() => {
 		if (projects === null || state.inputSearch !== '') return;
-		console.log('PXXXX');
 		setFilteredProjects(filterProjectsByTemplate(state.selectedTemplate, projects));
 	}, [projects, setFilteredProjects, state.inputSearch, state.selectedTemplate]);
 

--- a/client/src/pages/my-projects/helpers/search-projects.ts
+++ b/client/src/pages/my-projects/helpers/search-projects.ts
@@ -11,7 +11,6 @@ const getProjectWithKeywordIncluded = (project: ProjectState, keywords: string[]
 
 export const searchProjects = (projects: ProjectState[], searchText: string): ProjectState[] => {
 	if (searchText === '') return projects;
-	console.log('search');
 
 	const keywords = searchText.toLowerCase().trim().split(' ');
 


### PR DESCRIPTION
## Ticket

**Title:** [BUG] Le projet ne se met pas a jour si on supprime le main file
**Notion Link:** https://www.notion.so/jkergal/BUG-Le-projet-ne-se-met-pas-a-jour-si-on-supprime-le-main-file-26c15d3b621943a7b2d4b4a8162d782b?pvs=4

## Description

- Update  `onContextMenuAction` function to set new `mainFile` when `selectedNode` is equal to currently `mainFile`.
- Removed garbage console.logs.

Closes #95 

## Guidelines

🔗 Link your PRs to their related Notion tickets
✍️ Use the commit convention to your pull request title
📃 If your code affects the build, update `README.md`
🚫 Do not merge a PR until all comments are resolved
🗑 Remove your branch after merging
