### PR TITLE
feat(client): include set as main file on file explorer

### DIFF
--- a/client/src/context/project/project.context.tsx
+++ b/client/src/context/project/project.context.tsx
@@ -43,10 +43,12 @@ export const ProjectProvider = ({ children }: { children: ReactNode }) => {
 	useEffect(() => {
 		if (lastSavedProjectData?.files !== undefined && currentProjectData?.files !== undefined) {
 			const hasProjectNameChanged = currentProjectData?.name !== lastSavedProjectData?.name;
+			const hasMainFileChanged = currentProjectData?.main !== lastSavedProjectData?.main;
 
 			setIsProjectSaved(
 				!hasSandpackFilesChanged(lastSavedProjectData?.files, currentProjectData?.files) &&
-					!hasProjectNameChanged
+					!hasProjectNameChanged &&
+					!hasMainFileChanged
 			);
 		}
 	}, [currentProjectData, lastSavedProjectData]);

--- a/client/src/context/project/project.context.tsx
+++ b/client/src/context/project/project.context.tsx
@@ -1,4 +1,4 @@
-import { hasSandpackFilesChanged } from 'helpers/has-sandpack-files-changed';
+import { hasMainFileChanged, hasSandpackFilesChanged } from 'helpers/has-sandpack-files-changed';
 import { ReactNode, createContext, useEffect, useState } from 'react';
 import { ProjectContextData, SetProjectContextData } from 'types/project';
 
@@ -43,12 +43,11 @@ export const ProjectProvider = ({ children }: { children: ReactNode }) => {
 	useEffect(() => {
 		if (lastSavedProjectData?.files !== undefined && currentProjectData?.files !== undefined) {
 			const hasProjectNameChanged = currentProjectData?.name !== lastSavedProjectData?.name;
-			const hasMainFileChanged = currentProjectData?.main !== lastSavedProjectData?.main;
 
 			setIsProjectSaved(
 				!hasSandpackFilesChanged(lastSavedProjectData?.files, currentProjectData?.files) &&
 					!hasProjectNameChanged &&
-					!hasMainFileChanged
+					!hasMainFileChanged(lastSavedProjectData?.main, currentProjectData?.main)
 			);
 		}
 	}, [currentProjectData, lastSavedProjectData]);

--- a/client/src/helpers/has-sandpack-files-changed.ts
+++ b/client/src/helpers/has-sandpack-files-changed.ts
@@ -20,6 +20,10 @@ export const hasSandpackFilesChanged = (obj1: SandpackFiles, obj2: SandpackFiles
 	return false;
 };
 
+export const hasMainFileChanged = (previous: string, current: string): boolean => {
+	return previous !== current;
+};
+
 const isSandpackFileEqual = (
 	file1: string | SandpackFile,
 	file2: string | SandpackFile

--- a/client/src/pages/code/_components/context-menu.tsx
+++ b/client/src/pages/code/_components/context-menu.tsx
@@ -41,6 +41,14 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({ position, onClose, onA
 				<li>
 					<button
 						className='flex w-full items-start px-3 py-1 hover:bg-dark-700'
+						onClick={(event) => handleAction('set-main', node, event)}
+					>
+						Set as main file
+					</button>
+				</li>
+				<li>
+					<button
+						className='flex w-full items-start px-3 py-1 hover:bg-dark-700'
 						onClick={(event) => handleAction('delete', node, event)}
 					>
 						Delete

--- a/client/src/pages/code/_components/custom-file-explorer.tsx
+++ b/client/src/pages/code/_components/custom-file-explorer.tsx
@@ -65,8 +65,18 @@ export const CustomFileExplorer = ({ className, files }: CustomFileExplorerProps
 		};
 
 		const onContextMenuAction = (action: string, node: TreeNode, event: React.MouseEvent) => {
+			if (action === 'open' && selectedNode !== null) {
+				sandpack.openFile(selectedNode.path);
+			}
 			if (action === 'rename' && selectedNode !== null) {
 				handleRenameStart(selectedNode, event);
+			}
+			if (action === 'set-main' && selectedNode !== null) {
+				if (selectedNode.path !== currentProjectData?.main && currentProjectData !== null) {
+					currentProjectData.main = selectedNode.path;
+
+					toast.success('Main file successfully set.');
+				}
 			}
 			if (action === 'delete' && selectedNode !== null) {
 				if (selectedNode.path === currentProjectData?.main) {
@@ -76,6 +86,8 @@ export const CustomFileExplorer = ({ className, files }: CustomFileExplorerProps
 					currentProjectData.main = arrayOfMainFile[0];
 				}
 				sandpack.deleteFile(selectedNode.path);
+
+				toast.success('File successfully deleted.');
 			}
 		};
 

--- a/client/src/pages/code/_components/custom-file-explorer.tsx
+++ b/client/src/pages/code/_components/custom-file-explorer.tsx
@@ -74,6 +74,7 @@ export const CustomFileExplorer = ({ className, files }: CustomFileExplorerProps
 			if (action === 'set-main' && selectedNode !== null) {
 				if (selectedNode.path !== currentProjectData?.main && currentProjectData !== null) {
 					currentProjectData.main = selectedNode.path;
+					sandpack.setActiveFile(currentProjectData.main);
 
 					toast.success('Main file successfully set.');
 				}

--- a/client/src/pages/code/_components/sandpack.container.tsx
+++ b/client/src/pages/code/_components/sandpack.container.tsx
@@ -1,7 +1,7 @@
 import { SandpackFiles, useSandpack } from '@codesandbox/sandpack-react';
 import ProjectContext from 'context/project/project.context';
 import { getAddedFilePath } from 'helpers/get-added-file-path';
-import { hasSandpackFilesChanged } from 'helpers/has-sandpack-files-changed';
+import { hasMainFileChanged, hasSandpackFilesChanged } from 'helpers/has-sandpack-files-changed';
 import { useContext, useEffect, useRef } from 'react';
 import { ProjectContextData } from 'types/project';
 
@@ -24,6 +24,10 @@ export const SandpackContainer = ({ children }: SandpackContainerProps) => {
 		currentProjectData !== null ? currentProjectData.files : null
 	);
 
+	const previousMainFileRef = useRef<string | null>(
+		currentProjectData !== null ? currentProjectData.main : null
+	);
+
 	useEffect(() => {
 		setActiveFile(sandpack.activeFile);
 	}, [sandpack.activeFile, setActiveFile]);
@@ -36,6 +40,23 @@ export const SandpackContainer = ({ children }: SandpackContainerProps) => {
 
 	useEffect(() => {
 		const newFilePath = getAddedFilePath(previousFilesRef.current, sandpack.files);
+
+		if (
+			previousMainFileRef.current !== null &&
+			hasMainFileChanged(previousMainFileRef.current, sandpack.activeFile)
+		) {
+			previousFilesRef.current = sandpack.files;
+			previousMainFileRef.current = sandpack.activeFile;
+
+			return setCurrentProjectData(
+				(previousState) =>
+					({
+						...previousState,
+						main: sandpack.activeFile,
+						files: sandpack.files
+					} as ProjectContextData)
+			);
+		}
 
 		if (
 			previousFilesRef.current !== null &&

--- a/client/src/pages/code/_helpers/rename-file.ts
+++ b/client/src/pages/code/_helpers/rename-file.ts
@@ -9,4 +9,5 @@ export const renameFile = (newName: string, oldNode: TreeNode, sandpack: Sandpac
 
 	sandpack.addFile(`${parentPath}/${newName}`, oldNode.code);
 	sandpack.openFile(`${parentPath}/${newName}`);
+	sandpack.setActiveFile(`${parentPath}/${newName}`);
 };

--- a/client/src/pages/code/code.service.tsx
+++ b/client/src/pages/code/code.service.tsx
@@ -69,7 +69,7 @@ export const mapProjectDataResponse = (data: ProjectDataResponse) => {
 };
 
 export const useGetProjectService = (projectId: string) => {
-	const { setCurrentProjectData, setLastSavedProjectData, setActiveFile, setVisibleFiles } =
+	const { setCurrentProjectData, setLastSavedProjectData, setActiveFile } =
 		useContext(ProjectContext);
 
 	const { loading, data, error, refetch } = useQuery<


### PR DESCRIPTION
## Ticket

**Title:** ETQMembre, j’ai peux definir le main file du projet.
**Notion Link:** https://www.notion.so/jkergal/ETQMembre-j-ai-peux-definir-le-main-file-du-projet-03ed02d04d494bc2a1763a3918f088c7?pvs=4

## Description

- Include new menu option `Set as main file`, in the file explorer. 
- Update `custom-file-explorer` to include `set as main file` and `open`.
- Update `custom-file-explorer` to update when delete file show a `toast`.
- Update `page.context` to set as `modification` when change main file of project.
- Update `sandpack.container` to create main file changes watcher.
- Create `hasMainFileChanged `helper.
- Update `project.context` to include `hasMainFileChanged `verification to save project.

## Guidelines

🔗 Link your PRs to their related Notion tickets
✍️ Use the commit convention to your pull request title
📃 If your code affects the build, update `README.md`
🚫 Do not merge a PR until all comments are resolved
🗑 Remove your branch after merging
